### PR TITLE
Add example blueprint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ before_script:
 
 script:
     - gulp lint
+    - mkdir -p ~/.kelda/infra/ && mv ./testInfra.js ~/.kelda/infra/default.js
     - ./kelda inspect ./node.js graphviz
+    - ./kelda inspect ./nodeExample.js graphviz
 
 notifications:
     slack:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,37 @@
-# Node.js for Kelda
+# Node.js and MongoDB for Kelda
 
-This repository implements a Node.js specification for Kelda.js.  See
-[Kelda](http://kelda.io) for more information.
+This repository contains a blueprint for deploying a Node.js and MongoDB
+application to the cloud. Kelda's [Quick Start](http://docs.kelda.io/#quick-start)
+guide explains how to use this blueprint to deploy Kelda's Node.js/MongoDB [sample application](https://github.com/kelda/node-todo).
+
+## Deploying Your Own Node.js and MongoDB Application
+This section explains how to deploy another app than the sample TODO app.
+
+1. **Set the database URI**. In your Node.js application code, use the `MONGO_URI`
+environment variable to connect to the MongoDB. Using mongoose that would be:
+
+    ```javascript
+    var mongoose = require('mongoose');
+    mongoose.connect(process.env.MONGO_URI);
+    ```
+
+    For an example, see how [config/database.js](https://github.com/kelda/node-todo/blob/master/config/database.js#L3)
+    in the sample app sets to `localUrl` to be the `MONGO_URI`. The [server.js](https://github.com/kelda/node-todo/blob/master/server.js#L12)
+    file then uses this URL to connect to MongoDB.
+
+2. **Point the blueprint to your git repository**. The `nodeRepository` variable
+in the [nodeExample.js](https://github.com/kelda/node-todo/blob/master/nodeExample.js)
+blueprint specifies the git repository containing the Node.js/MongoDB application that
+should be deployed. Change the variable to point to your git repository.
+
+    ```javascript
+    const nodeRepository = 'https://github.com/<githubUser>/<nodeMongoApp>.git';
+    ```
+
+3. **Deploy the Application**. Follow the [Quick Start](http://docs.kelda.io/#quick-start)
+guide in the Kelda docs, but make sure to modify the `nodeExample` blueprint as
+described above before executing `kelda run ./nodeExample.js`.
+
+## More Info
+Check out [our website](http://kelda.io) and [docs](http://docs.kelda.io) for
+more information and tutorials.

--- a/nodeExample.js
+++ b/nodeExample.js
@@ -1,0 +1,31 @@
+const kelda = require('kelda');
+const Mongo = require('@kelda/mongo');
+const Node = require('./node');
+
+// The GitHub repository containing the code for the Node.js and MongoDB app to
+// deploy. Change this to deploy a different application.
+const nodeRepository = 'https://github.com/kelda/node-todo.git';
+
+// The port the app will be listening on. This should match the port number
+// passed to app.listen(), assuming `app` is an Express application.
+const port = 80;
+// The number of web servers and database instances.
+const count = 1;
+
+const mongo = new Mongo(count);
+const app = new Node({
+  nWorker: count,
+  repo: nodeRepository,
+  env: {
+    PORT: port.toString(),
+    MONGO_URI: mongo.uri('node-example'),
+  },
+});
+
+mongo.allowFrom(app.containers, mongo.port);
+kelda.allow(kelda.publicInternet, app.containers, port);
+
+const infra = kelda.baseInfrastructure();
+
+app.deploy(infra);
+mongo.deploy(infra);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "./node.js",
   "license": "MIT",
   "dependencies": {
-    "kelda": "0.x"
+    "kelda": "0.x",
+    "@kelda/mongo": "kelda/mongo"
   },
   "devDependencies": {
     "eslint": "^4.4.1",

--- a/testInfra.js
+++ b/testInfra.js
@@ -1,0 +1,7 @@
+// This file contains the base infrastructure used for the travis build.
+function infraGetter(kelda) {
+  const vmTemplate = new kelda.Machine({ provider: 'Amazon' });
+  return new kelda.Infrastructure(vmTemplate, vmTemplate);
+}
+
+module.exports = infraGetter;


### PR DESCRIPTION
In an upcoming update to Kelda's getting started guide, we'll use this Node/Mongo example blueprint instead of nginx.