### PR TITLE
blueprint: Use new constructor format

### DIFF
--- a/node.js
+++ b/node.js
@@ -35,12 +35,16 @@ function Node(cfg) {
 
   const env = cfg.env || {};
   const name = imageName(cfg.repo);
-  const image = new Image(name, `FROM keldaio/nodejs
-RUN git clone ${cfg.repo} . && npm install`);
+  const image = new Image({
+    name,
+    dockerfile: `FROM keldaio/nodejs
+RUN git clone ${cfg.repo} . && npm install`,
+  });
 
   this.containers = [];
   for (let i = 0; i < cfg.nWorker; i += 1) {
-    this.containers.push(new Container('node-app', image).withEnv(env));
+    this.containers.push(
+      new Container({ name: 'node-app', image, env }));
   }
 }
 

--- a/testInfra.js
+++ b/testInfra.js
@@ -1,7 +1,10 @@
 // This file contains the base infrastructure used for the travis build.
 function infraGetter(kelda) {
   const vmTemplate = new kelda.Machine({ provider: 'Amazon' });
-  return new kelda.Infrastructure(vmTemplate, vmTemplate);
+  return new kelda.Infrastructure({
+    masters: vmTemplate,
+    workers: vmTemplate,
+  });
 }
 
 module.exports = infraGetter;


### PR DESCRIPTION
The build will fail until the next release of Kelda (0.10.0). This should not be merged until then.